### PR TITLE
fix: hide progress & use metrics port in health check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,6 @@ COPY requirements.txt /requirements.txt
 RUN apk add --update --no-cache curl && \
 pip install -r /requirements.txt && rm -rf requirements.txt
 
-HEALTHCHECK --interval=1m CMD /usr/bin/curl -f http://localhost:9387/ || exit 1
+HEALTHCHECK --interval=1m CMD /usr/bin/curl -f -s http://localhost:$${METRICS_PORT:-9387}/ || exit 1
 
 ENTRYPOINT ["python","/sabnzbd_exporter.py"]


### PR DESCRIPTION
the sabnzbd exporter allows for changing the metrics port via `METRICS_PORT` but the health check doesn't follow that.  the healthcheck also emits useless info with the progress bar

this corrects both issues